### PR TITLE
Add phase status management + Division visual polish

### DIFF
--- a/src/app/domains/[slug]/operations/[operationId]/page.tsx
+++ b/src/app/domains/[slug]/operations/[operationId]/page.tsx
@@ -70,6 +70,59 @@ export default function OperationDetailPage({ params }: OperationDetailPageProps
     }
   }
 
+  // Activate a phase — only the NEXT sequential phase can be activated.
+  // Phases are ordered by sort_order: you must complete Phase 1 before
+  // Phase 2 can become active. Clicking any other phase just expands
+  // its detail panel for viewing.
+  async function activatePhase(phaseId: string) {
+    const phase = sortedPhases.find((p: any) => p.id === phaseId);
+    if (!phase) return;
+
+    // Completed phases and already-active phases just expand the detail
+    if (phase.status === "completed" || phase.status === "active") {
+      setExpandedPhase(phaseId);
+      return;
+    }
+
+    // Find the next activatable phase: the first pending phase where
+    // all phases before it (lower sort_order) are completed.
+    const nextActivatable = sortedPhases.find((p: any) => {
+      if (p.status !== "pending") return false;
+      // Check all phases with lower sort_order are completed
+      const priorPhases = sortedPhases.filter(
+        (prior: any) => prior.sort_order < p.sort_order
+      );
+      return priorPhases.every((prior: any) => prior.status === "completed");
+    });
+
+    // Only allow activation if this IS the next sequential phase
+    if (!nextActivatable || nextActivatable.id !== phaseId) {
+      // Not the next in sequence — just expand to view, don't activate
+      setExpandedPhase(phaseId);
+      return;
+    }
+
+    // Deactivate any currently active phase first
+    const currentlyActive = sortedPhases.find((p: any) => p.status === "active");
+    if (currentlyActive) {
+      await fetch(`/api/phases/${currentlyActive.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "pending" }),
+      });
+    }
+
+    // Activate the next sequential phase
+    await fetch(`/api/phases/${phaseId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "active" }),
+    });
+
+    setExpandedPhase(phaseId);
+    fetchOperation();
+  }
+
   if (loading) {
     return <div className="py-20 text-center text-zinc-500">Loading...</div>;
   }
@@ -185,7 +238,7 @@ export default function OperationDetailPage({ params }: OperationDetailPageProps
               <StepperTimeline
                 steps={timelineSteps}
                 color={color}
-                onStepClick={(id) => setExpandedPhase(id)}
+                onStepClick={(id) => activatePhase(id)}
               />
             ) : (
               <p className="text-sm text-zinc-600">No phases yet.</p>

--- a/src/lib/streaks.ts
+++ b/src/lib/streaks.ts
@@ -277,8 +277,64 @@ export async function runCompletionCascade(
   // If module isn't linked to a phase, no cascade to check
   if (!modulePhaseId) return events;
 
+  // Auto-activate: if this module's phase is still "pending", activate it
+  // ONLY if all prior phases (lower sort_order) are completed.
+  // This enforces sequential progression — you can't skip ahead.
+  const { data: currentPhase } = await supabase
+    .from("phases")
+    .select("status, operation_id, sort_order")
+    .eq("id", modulePhaseId)
+    .single();
+
+  if (currentPhase && currentPhase.status === "pending" && currentPhase.operation_id) {
+    // Check all prior phases are completed
+    const { data: priorPhases } = await supabase
+      .from("phases")
+      .select("status")
+      .eq("operation_id", currentPhase.operation_id)
+      .lt("sort_order", currentPhase.sort_order);
+
+    const allPriorCompleted = !priorPhases || priorPhases.length === 0 ||
+      priorPhases.every((p) => p.status === "completed");
+
+    if (allPriorCompleted) {
+      // Deactivate any currently active sibling phase
+      await supabase
+        .from("phases")
+        .update({ status: "pending", updated_at: new Date().toISOString() })
+        .eq("operation_id", currentPhase.operation_id)
+        .eq("status", "active");
+
+      // Activate this phase
+      await supabase
+        .from("phases")
+        .update({ status: "active", updated_at: new Date().toISOString() })
+        .eq("id", modulePhaseId);
+    }
+  }
+
   // Level 1: did this complete a phase?
   const phaseEvent = await checkPhaseCompletion(modulePhaseId);
+
+  // If the phase just completed, auto-activate the next sequential phase
+  if (phaseEvent && currentPhase?.operation_id) {
+    const { data: nextPhase } = await supabase
+      .from("phases")
+      .select("id")
+      .eq("operation_id", currentPhase.operation_id)
+      .eq("status", "pending")
+      .order("sort_order", { ascending: true })
+      .limit(1)
+      .single();
+
+    if (nextPhase) {
+      await supabase
+        .from("phases")
+        .update({ status: "active", updated_at: new Date().toISOString() })
+        .eq("id", nextPhase.id);
+    }
+  }
+
   if (!phaseEvent) return events;
   events.push(phaseEvent);
 


### PR DESCRIPTION
* **Apply Division-inspired visual design system / language**
* **enforce sequential phase progression with auto-advance on completion**
* **## Summary**
* **This PR includes two features (visual polish was merged in after its original PR failed to land on main):**
* 
* **\*\*Phase Status Management:\*\***
* **- Phases progress sequentially: Phase 1 must complete before Phase 2 activates**
* **- Click-to-activate only works on the next eligible phase in the timeline**
* **- Completing a module auto-activates its phase (if prior phases are done)**
* **- Completing a phase auto-activates the next pending phase**
* **- Cannot skip ahead — clicking out-of-order phases only expands the detail view**
* 
* **\*\*Division-Inspired Visual Polish:\*\***
* **- Dark tactical color palette with CSS grid texture background**
* **- Monospaced uppercase header and navigation styling**
* **- Tactical thin-line progress bars**
* **- Stripped all dual-mode (dark:) classes to dark-only**
* 
* **## Test plan**
* **- \[ ] Click Phase 2 while Phase 1 is pending → no activation, just expands**
* **- \[ ] Click Phase 1 → activates (pulsing dot)**
* **- \[ ] Complete all modules in Phase 1 → Phase 1 completes, Phase 2 auto-activates**
* **- \[ ] Complete all phases → operation completion overlay triggers**
* **- \[ ] Dashboard shows grid texture background and tactical styling**
* **- \[ ] Navigation uses monospaced uppercase styling**

